### PR TITLE
Make tsoa ignore node_modules

### DIFF
--- a/tsoa.json
+++ b/tsoa.json
@@ -13,5 +13,6 @@
   "routes": {
     "routesDir": "src/routes",
     "basePath": "/api/v1"
-  }
+  },
+  "ignore": ["**/node_modules/**"]
 }


### PR DESCRIPTION
avoid "Error: Multiple matching models found for referenced type Session" by tsoa

Signed-off-by: Hiroyuki Kirinuki <hiro5051@gmail.com>